### PR TITLE
Allow ServiceNow provider to read config from env vars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         env:
           # These secrets will need to be configured for the repository:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.5.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           go-version: 1.16
       - name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        uses: crazy-max/ghaction-import-gpg@v6
         env:
           # These secrets will need to be configured for the repository:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,9 @@ on:
   push:
     tags:
       - "v*"
+    branches:
+      - main
+      - 'releases/**'
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -18,10 +21,10 @@ jobs:
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6
-        env:
+        with:
           # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2.5.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
       - "v*"
     branches:
       - main
+      - master
       - 'releases/**'
 jobs:
   goreleaser:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 terraform-provider-servicenow*
 .vscode
+.idea
 coverage.out

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HOSTNAME=tyler.sh
 NAMESPACE=tylerhatton
 NAME=servicenow
 BINARY=terraform-provider-${NAME}
-VERSION=0.9.3
+VERSION=0.9.7-snapshot
 OS_ARCH=linux_amd64
 
 default: install

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,6 @@ provider "servicenow" {
 
 ### Required
 
-- **instance_url** (String) The Url of the ServiceNow instance to work with.
-- **password** (String, Sensitive) Password of the user to manage resources.
-- **username** (String) Username used to manage resources in the ServiceNow instance using Basic authentication.
+- **instance_url** (String) The Url of the ServiceNow instance to work with. Value can also be sourced from the SERVICENOW_INSTANCE_URL environment variable.
+- **password** (String, Sensitive) Password of the user to manage resources. Value can also be sourced from the SERVICENOW_USERNAME environment variable.
+- **username** (String) Username used to manage resources in the ServiceNow instance using Basic authentication. Value can also be sourced from the SERVICENOW_PASSWORD environment variable.

--- a/servicenow/provider.go
+++ b/servicenow/provider.go
@@ -12,19 +12,25 @@ func Provider() *schema.Provider {
 		Schema: map[string]*schema.Schema{
 			"instance_url": {
 				Type:        schema.TypeString,
-				Description: "The Url of the ServiceNow instance to work with.",
 				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SERVICENOW_INSTANCE_URL", nil),
+				Description: "The Url of the ServiceNow instance to work with. " +
+					"Value can also be sourced from the SERVICENOW_INSTANCE_URL environment variable.",
 			},
 			"username": {
 				Type:        schema.TypeString,
-				Description: "Username used to manage resources in the ServiceNow instance using Basic authentication.",
 				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SERVICENOW_USER", nil),
+				Description: "Username used to manage resources in the ServiceNow instance using Basic authentication. " +
+					"Value can also be sourced from the SERVICENOW_USER environment variable.",
 			},
 			"password": {
 				Type:        schema.TypeString,
-				Description: "Password of the user to manage resources.",
 				Required:    true,
 				Sensitive:   true,
+				DefaultFunc: schema.EnvDefaultFunc("SERVICENOW_PASSWORD", nil),
+				Description: "Password of the user to manage resources. " +
+					"Value can also be sourced from the SERVICENOW_PASSWORD environment variable.",
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
This PR allow setting environment variables (SERVICENOW_INSTANCE_URL, SERVICENOW_USERNAME, SERVICENOW_PASSWORD) so the information does not need to be encoded into the provider.tf file at runtime. This should allow for more secure deployments, removing passwords from source code, as well as the flexibility of deploying to multiple instances by adjusting the environment variables.

I am unable to run the unit tests, and have raised a separate issue: #6 